### PR TITLE
Add tweet embedding workflow

### DIFF
--- a/src/agent/workflows/embedding_work.test.ts
+++ b/src/agent/workflows/embedding_work.test.ts
@@ -1,0 +1,42 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { AppDataSource } from "../../db/ormconfig";
+import { ChatHistory, getAllChatHistories } from "../../entities";
+import { createBaseCtx } from "../workflow_manager";
+import { embeddingWork } from "./embedding_work";
+
+describe("workflow: embedding", async () => {
+	const baseCtx = await createBaseCtx(true, true);
+	baseCtx.models.embedding = baseCtx.models.common;
+	const ctx: any = {
+		...baseCtx,
+		state: {
+			name: "embedding",
+		},
+	};
+	const db = baseCtx.db;
+	const ownId = baseCtx.twitter.ownId;
+
+	beforeAll(async () => {
+		await db.saveEntities([
+			new ChatHistory(ownId, "tweet1", "hello world"),
+			new ChatHistory(ownId, "tweet2", "another tweet"),
+		]);
+	});
+
+	afterAll(async () => {
+		await db.makeTransaction(async () => {
+			await AppDataSource.getRepository(ChatHistory).delete({});
+		});
+	});
+
+	test("embeddingWork works", async () => {
+		const err = await embeddingWork(ctx);
+		expect(err).toBeNull();
+
+		const histories = await getAllChatHistories(db);
+		expect(histories.length).toBe(2);
+		for (const h of histories) {
+			expect(h.embedding).not.toBeNull();
+		}
+	});
+});

--- a/src/agent/workflows/embedding_work.ts
+++ b/src/agent/workflows/embedding_work.ts
@@ -1,0 +1,43 @@
+import { IsNull } from "typeorm";
+import { ChatHistory } from "../../entities/chat_history_entity";
+import type { ILLMModel } from "../../models";
+import logger from "../../utils/logger";
+import type { BaseWorkflowContext, WorkflowContext, WorkflowState } from "../workflow_manager";
+import { handleErrors, validateStateName } from "./common";
+
+export type EmbeddingState = WorkflowState & {
+	name: "embedding";
+};
+
+export const createEmbeddingCtx = (baseCtx: BaseWorkflowContext): WorkflowContext => {
+	const state: EmbeddingState = { name: "embedding" };
+	baseCtx.models[state.name] = baseCtx.models.embed;
+	return { ...baseCtx, state };
+};
+
+export const embeddingWork = async (ctx: WorkflowContext): Promise<Error | null> => {
+	validateStateName(ctx.state, "embedding");
+
+	const errs: Error[] = [];
+	const model = ctx.models[ctx.state.name] as ILLMModel;
+
+	await ctx.db.makeTransaction(async (queryRunner) => {
+		const repo = queryRunner.manager.getRepository(ChatHistory);
+		const histories = await repo.find({ where: { embedding: IsNull() } });
+
+		await model.embedContext(async (embedder) => {
+			for (const history of histories) {
+				try {
+					const embeds = await embedder(history.content);
+					history.embedding = `[${embeds.join(",")}]`;
+					await repo.save(history);
+				} catch (err) {
+					logger.warn(err, `Embedding error id: ${history.id}`);
+					errs.push(new Error(`${(err as Error).message} id: ${history.id}`));
+				}
+			}
+		});
+	});
+
+	return handleErrors("embedding", errs);
+};


### PR DESCRIPTION
## Summary
- implement `embedding_work` to compute embeddings for ChatHistory rows that don't have them
- add test for the new embedding workflow

## Testing
- `bun run fmt`
- `bun run lint`
- `npm test` *(fails: Missing environment variables and model files)*

------
https://chatgpt.com/codex/tasks/task_e_6841345dac008330b7cd2cc05a102fe4