### PR TITLE
Add LLM API server

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -78,6 +78,14 @@ X_SERVER_HOST=127.0.0.1
 X_SERVER_PORT=3000
 
 ############################################
+# LLM API Server Configuration
+############################################
+LLM_SERVER_HOST=127.0.0.1
+LLM_SERVER_PORT=3100
+LLM_SERVER_TOKEN=
+LLM_EMBED_TIMEOUT=300000
+
+############################################
 # Directory Configuration
 ############################################
 DIR_EMBEDDING_DOCUMENT=./data/docs

--- a/package.json
+++ b/package.json
@@ -13,9 +13,10 @@
 		"typeorm:base": "bun run --bun typeorm -d ./src/db/ormconfig.ts",
 		"typeorm:init": "bun typeorm:base migration:generate ./src/db/migrations/init",
 		"typeorm:up": "bun typeorm:base migration:run",
-		"typeorm:down": "bun typeorm:base migration:revert",
-		"chain": "anvil"
-	},
+                "typeorm:down": "bun typeorm:base migration:revert",
+                "chain": "anvil",
+                "llm-server": "bun run src/cmd/llm_server.ts"
+        },
 	"devDependencies": {
 		"@biomejs/biome": "1.9.4",
 		"@types/bun": "latest"

--- a/src/cmd/llm_server.ts
+++ b/src/cmd/llm_server.ts
@@ -1,9 +1,6 @@
-import express from "express";
-import type { Request, Response, NextFunction } from "express";
-import { createInitalizedEmbModel, createInitalizedModel } from "../models";
+import { LLMServer } from "../models/server";
 import { Env } from "../utils/env";
 import logger from "../utils/logger";
-import { LLamaCppModel } from "../models/llama_cpp";
 
 async function main() {
     const host = Env.string("LLM_SERVER_HOST");
@@ -11,80 +8,15 @@ async function main() {
     const token = Env.string("LLM_SERVER_TOKEN");
     const embedTimeout = Env.number("LLM_EMBED_TIMEOUT");
 
-    const app = express();
-    app.use(express.json());
-
-    const inferModel = (await createInitalizedModel()) as LLamaCppModel;
-    const embedModel = (await createInitalizedEmbModel()) as LLamaCppModel;
-
-    const auth = (req: Request, res: Response, next: NextFunction) => {
-        const authHeader = req.headers["authorization"] || "";
-        if (authHeader !== `Bearer ${token}`) {
-            res.status(401).json({ error: "Unauthorized" });
-            return;
-        }
-        next();
-    };
-
-    app.post("/infer", auth, async (req: Request, res: Response) => {
-        const { prompt } = req.body as { prompt?: string };
-        if (!prompt) {
-            res.status(400).json({ error: "prompt required" });
-            return;
-        }
-        res.setHeader("Content-Type", "text/event-stream");
-        res.setHeader("Cache-Control", "no-cache");
-        res.setHeader("Connection", "keep-alive");
-        res.flushHeaders();
-
-        const session = inferModel.getSession("");
-        try {
-            await session.prompt(prompt, {
-                trimWhitespaceSuffix: true,
-                stopOnAbortSignal: true,
-                signal: undefined,
-                onTextChunk: (chunk: string) => {
-                    res.write(`data: ${chunk}\n\n`);
-                },
-            });
-            res.write("data: [DONE]\n\n");
-        } catch (err) {
-            logger.error(err, "infer error");
-            res.write(`event: error\ndata: ${(err as Error).message}\n\n`);
-        } finally {
-            session.dispose();
-            res.end();
-        }
-    });
-
-    app.post("/embedding", auth, async (req: Request, res: Response) => {
-        const { text } = req.body as { text?: string };
-        if (!text) {
-            res.status(400).json({ error: "text required" });
-            return;
-        }
-        res.setTimeout(embedTimeout);
-        try {
-            const emb = await embedModel.embed(text);
-            res.json({ embedding: emb });
-        } catch (err) {
-            logger.error(err, "embedding error");
-            res.status(500).json({ error: (err as Error).message });
-        }
-    });
-
-    const server = app.listen(port, host, () => {
-        logger.info(`llm api server started on http://${host}:${port}`);
-    });
+    const server = new LLMServer(host, port, token, embedTimeout);
+    await server.start();
 
     const close = async () => {
-        server.close();
-        await inferModel.close();
-        if (embedModel !== inferModel) await embedModel.close();
-        logger.info("llm api server closed");
+        await server.close();
     };
     process.on("SIGINT", close);
     process.on("SIGTERM", close);
 }
 
 main().catch((err) => logger.error(err));
+

--- a/src/cmd/llm_server.ts
+++ b/src/cmd/llm_server.ts
@@ -1,0 +1,90 @@
+import express from "express";
+import type { Request, Response, NextFunction } from "express";
+import { createInitalizedEmbModel, createInitalizedModel } from "../models";
+import { Env } from "../utils/env";
+import logger from "../utils/logger";
+import { LLamaCppModel } from "../models/llama_cpp";
+
+async function main() {
+    const host = Env.string("LLM_SERVER_HOST");
+    const port = Env.number("LLM_SERVER_PORT");
+    const token = Env.string("LLM_SERVER_TOKEN");
+    const embedTimeout = Env.number("LLM_EMBED_TIMEOUT");
+
+    const app = express();
+    app.use(express.json());
+
+    const inferModel = (await createInitalizedModel()) as LLamaCppModel;
+    const embedModel = (await createInitalizedEmbModel()) as LLamaCppModel;
+
+    const auth = (req: Request, res: Response, next: NextFunction) => {
+        const authHeader = req.headers["authorization"] || "";
+        if (authHeader !== `Bearer ${token}`) {
+            res.status(401).json({ error: "Unauthorized" });
+            return;
+        }
+        next();
+    };
+
+    app.post("/infer", auth, async (req: Request, res: Response) => {
+        const { prompt } = req.body as { prompt?: string };
+        if (!prompt) {
+            res.status(400).json({ error: "prompt required" });
+            return;
+        }
+        res.setHeader("Content-Type", "text/event-stream");
+        res.setHeader("Cache-Control", "no-cache");
+        res.setHeader("Connection", "keep-alive");
+        res.flushHeaders();
+
+        const session = inferModel.getSession("");
+        try {
+            await session.prompt(prompt, {
+                trimWhitespaceSuffix: true,
+                stopOnAbortSignal: true,
+                signal: undefined,
+                onTextChunk: (chunk: string) => {
+                    res.write(`data: ${chunk}\n\n`);
+                },
+            });
+            res.write("data: [DONE]\n\n");
+        } catch (err) {
+            logger.error(err, "infer error");
+            res.write(`event: error\ndata: ${(err as Error).message}\n\n`);
+        } finally {
+            session.dispose();
+            res.end();
+        }
+    });
+
+    app.post("/embedding", auth, async (req: Request, res: Response) => {
+        const { text } = req.body as { text?: string };
+        if (!text) {
+            res.status(400).json({ error: "text required" });
+            return;
+        }
+        res.setTimeout(embedTimeout);
+        try {
+            const emb = await embedModel.embed(text);
+            res.json({ embedding: emb });
+        } catch (err) {
+            logger.error(err, "embedding error");
+            res.status(500).json({ error: (err as Error).message });
+        }
+    });
+
+    const server = app.listen(port, host, () => {
+        logger.info(`llm api server started on http://${host}:${port}`);
+    });
+
+    const close = async () => {
+        server.close();
+        await inferModel.close();
+        if (embedModel !== inferModel) await embedModel.close();
+        logger.info("llm api server closed");
+    };
+    process.on("SIGINT", close);
+    process.on("SIGTERM", close);
+}
+
+main().catch((err) => logger.error(err));

--- a/src/models/server.ts
+++ b/src/models/server.ts
@@ -1,0 +1,106 @@
+import type { Server } from "node:http";
+import express, { type NextFunction, type Request, type Response } from "express";
+import { createInitalizedEmbModel, createInitalizedModel } from "./index";
+import { LLamaCppModel } from "./llama_cpp";
+import logger from "../utils/logger";
+
+export class LLMServer {
+    readonly host: string;
+    readonly port: number;
+    readonly token: string;
+    readonly embedTimeout: number;
+    #server?: Server;
+    #inferModel?: LLamaCppModel;
+    #embedModel?: LLamaCppModel;
+    #closing = false;
+
+    constructor(host: string, port: number, token: string, embedTimeout: number) {
+        this.host = host;
+        this.port = port;
+        this.token = token;
+        this.embedTimeout = embedTimeout;
+    }
+
+    async start(): Promise<void> {
+        const app = express();
+        app.use(express.json());
+
+        this.#inferModel = (await createInitalizedModel()) as LLamaCppModel;
+        this.#embedModel = (await createInitalizedEmbModel()) as LLamaCppModel;
+
+        const auth = (req: Request, res: Response, next: NextFunction) => {
+            const authHeader = req.headers["authorization"] || "";
+            if (authHeader !== `Bearer ${this.token}`) {
+                res.status(401).json({ error: "Unauthorized" });
+                return;
+            }
+            next();
+        };
+
+        app.post("/infer", auth, async (req: Request, res: Response) => {
+            const { prompt } = req.body as { prompt?: string };
+            if (!prompt) {
+                res.status(400).json({ error: "prompt required" });
+                return;
+            }
+            res.setHeader("Content-Type", "text/event-stream");
+            res.setHeader("Cache-Control", "no-cache");
+            res.setHeader("Connection", "keep-alive");
+            res.flushHeaders();
+
+            const session = this.#inferModel!.getSession("");
+            try {
+                await session.prompt(prompt, {
+                    trimWhitespaceSuffix: true,
+                    stopOnAbortSignal: true,
+                    signal: undefined,
+                    onTextChunk: (chunk: string) => {
+                        res.write(`data: ${chunk}\n\n`);
+                    },
+                });
+                res.write("data: [DONE]\n\n");
+            } catch (err) {
+                logger.error(err, "infer error");
+                res.write(`event: error\ndata: ${(err as Error).message}\n\n`);
+            } finally {
+                session.dispose();
+                res.end();
+            }
+        });
+
+        app.post("/embedding", auth, async (req: Request, res: Response) => {
+            const { text } = req.body as { text?: string };
+            if (!text) {
+                res.status(400).json({ error: "text required" });
+                return;
+            }
+            res.setTimeout(this.embedTimeout);
+            try {
+                const emb = await this.#embedModel!.embed(text);
+                res.json({ embedding: emb });
+            } catch (err) {
+                logger.error(err, "embedding error");
+                res.status(500).json({ error: (err as Error).message });
+            }
+        });
+
+        this.#server = app.listen(this.port, this.host, () => {
+            logger.info(`llm api server started on http://${this.host}:${this.port}`);
+        });
+    }
+
+    async close(): Promise<void> {
+        if (this.#closing) return;
+        this.#closing = true;
+        if (this.#server) {
+            await new Promise<void>((resolve) => {
+                this.#server?.close(() => resolve());
+            });
+        }
+        await this.#inferModel?.close();
+        if (this.#embedModel && this.#embedModel !== this.#inferModel) await this.#embedModel.close();
+        logger.info("llm api server closed");
+        this.#closing = false;
+    }
+}
+


### PR DESCRIPTION
## Summary
- create `llm_server` command to serve LLM inference and embedding over HTTP
- support bearer token auth and SSE streaming
- expose configuration in `.env.sample`
- add `llm-server` script in package.json

## Testing
- `bun test` *(fails: Missing env vars and packages)*

------
https://chatgpt.com/codex/tasks/task_e_68441979ddf08330bb22167da8e6527d