### PR TITLE
Implement t.co URL resolver

### DIFF
--- a/src/utils/web.test.ts
+++ b/src/utils/web.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { extractArticleContent } from './web';
+import { extractArticleContent, resolveShortUrl } from './web';
 
 test('extracts title and content from a real article', async () => {
   const url = 'https://oasyswallet.zendesk.com/hc/en-us/articles/12578425563791-Campaign-Announcement-Oassy-hunt';
@@ -12,4 +12,11 @@ test('extracts title and content from a real article', async () => {
   expect(result.content.length).toBeGreaterThan(100); // reasonable article length
 
   expect(result).toHaveProperty('publishedTime');
+});
+
+test('resolveShortUrl expands t.co link', async () => {
+  const shortUrl = 'https://t.co/jkjL5ixOIl';
+  const resolved = await resolveShortUrl(shortUrl);
+  expect(resolved).not.toBe(shortUrl);
+  expect(resolved.startsWith('https://')).toBe(true);
 });

--- a/src/utils/web.ts
+++ b/src/utils/web.ts
@@ -29,5 +29,14 @@ export const extractArticleContent = async (url: string): Promise<{
     content: article.textContent,
     publishedTime: article.publishedTime || null,
   };
-}
+};
+
+export const resolveShortUrl = async (url: string): Promise<string> => {
+  try {
+    const response = await fetch(url, { redirect: 'follow' });
+    return response.url;
+  } catch (err) {
+    throw new Error(`Failed to resolve ${url}: ${(err as Error).message}`);
+  }
+};
 


### PR DESCRIPTION
## Summary
- add `resolveShortUrl` helper to follow redirects
- test that the resolver expands t.co links

## Testing
- `bun test` *(fails: Invalid log level, network access issues)*

------
https://chatgpt.com/codex/tasks/task_e_6849683137e0833083ce4f5b46a7c717