### PR TITLE
Add Google Custom Search util

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -41,6 +41,7 @@ DB_SCHEMA_TEST=aifaucet
 # API Configuration
 ############################################
 AP_KEY_OPENAI=
+AP_KEY_GOOGLE_CUSTOM_SEARCH=
 
 ############################################
 # Splitter Configuration

--- a/src/utils/google.test.ts
+++ b/src/utils/google.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from "bun:test";
+import { googleCustomSearch } from "./google";
+
+// Basic test to ensure URL is constructed with provided parameters
+
+test("googleCustomSearch builds request URL with api key", async () => {
+    const originalFetch = global.fetch;
+    let calledUrl = "";
+    global.fetch = async (url: string) => {
+        calledUrl = url.toString();
+        return new Response(JSON.stringify({ items: [] }), { status: 200 });
+    };
+
+    process.env.AP_KEY_GOOGLE_CUSTOM_SEARCH = "dummy";
+    await googleCustomSearch("hello world", "cx-id", { start: 2, num: 5 });
+
+    expect(calledUrl.includes("key=dummy")).toBe(true);
+    expect(calledUrl.includes("cx=cx-id")).toBe(true);
+    expect(calledUrl.includes("q=hello%20world")).toBe(true);
+    expect(calledUrl.includes("start=2")).toBe(true);
+    expect(calledUrl.includes("num=5")).toBe(true);
+
+    global.fetch = originalFetch;
+});

--- a/src/utils/google.ts
+++ b/src/utils/google.ts
@@ -1,0 +1,31 @@
+import { Env } from "./env";
+
+export interface GoogleSearchResultItem {
+    title: string;
+    link: string;
+    snippet: string;
+}
+
+export interface GoogleSearchResponse {
+    items?: GoogleSearchResultItem[];
+}
+
+export async function googleCustomSearch(
+    query: string,
+    cx: string,
+    opts?: { start?: number; num?: number },
+): Promise<GoogleSearchResponse> {
+    const apiKey = Env.string("AP_KEY_GOOGLE_CUSTOM_SEARCH");
+    const url = new URL("https://www.googleapis.com/customsearch/v1");
+    url.searchParams.set("key", apiKey);
+    url.searchParams.set("cx", cx);
+    url.searchParams.set("q", query);
+    if (opts?.start) url.searchParams.set("start", `${opts.start}`);
+    if (opts?.num) url.searchParams.set("num", `${opts.num}`);
+
+    const res = await fetch(url.toString());
+    if (!res.ok) {
+        throw new Error(`Failed to fetch from Google Custom Search: ${res.status} ${res.statusText}`);
+    }
+    return (await res.json()) as GoogleSearchResponse;
+}


### PR DESCRIPTION
## Summary
- add new env variable `AP_KEY_GOOGLE_CUSTOM_SEARCH`
- implement `googleCustomSearch` util for calling Google Custom Search API
- test that request URL is built correctly

## Testing
- `bun test` *(fails: missing env vars and blocked network)*

------
https://chatgpt.com/codex/tasks/task_e_685a32df5fdc833099a2bfa8fc6c239f